### PR TITLE
Inherit from stream

### DIFF
--- a/src/ESPTelnet.cpp
+++ b/src/ESPTelnet.cpp
@@ -72,19 +72,6 @@ void ESPTelnet::loop() {
       isConnected = false;
       ip = "";
     }
-  // gather input
-  if (client && isConnected && client.available()) {    
-    char c = client.read();
-    if (c != '\n') {
-      if (c >= 32) {
-        input += c; 
-      }
-    // EOL -> send input
-    } else {
-      if (on_input != NULL) on_input(input);
-      input = "";
-      }
-  }
     yield();
   } 
   
@@ -170,12 +157,6 @@ void ESPTelnet::onReconnect(CallbackFunction f) {
 
 void ESPTelnet::onDisconnect(CallbackFunction f) { 
   on_disconnect = f; 
-}
-
-/* ------------------------------------------------- */
-
-void ESPTelnet::onInputReceived(CallbackFunction f) { 
-  on_input = f; 
 }
 
 /* ------------------------------------------------- */

--- a/src/ESPTelnet.cpp
+++ b/src/ESPTelnet.cpp
@@ -89,37 +89,51 @@ void ESPTelnet::loop() {
   } 
   
 /* ------------------------------------------------- */
-    
-void ESPTelnet::print(char c) {
+
+int ESPTelnet::available() {
   if (client && isClientConnected(client)) {
-    client.print(c); 
+    return client.available(); 
+  } else {
+    return 0;
   }
 }
 
 /* ------------------------------------------------- */
 
-void ESPTelnet::print(String str) {
+int ESPTelnet::read() {
   if (client && isClientConnected(client)) {
-    client.print(str); 
+    return client.read(); 
+  } else {
+    return 0;
   }
 }
 
 /* ------------------------------------------------- */
 
-void ESPTelnet::println(String str) { 
-  client.print(str + "\n"); 
+int ESPTelnet::peek() {
+  if (client && isClientConnected(client)) {
+    return client.peek(); 
+  } else {
+    return 0;
+  }
 }
 
 /* ------------------------------------------------- */
 
-void ESPTelnet::println(char c) { 
-  client.print(c + "\n"); 
+void ESPTelnet::flush() {
+  if (client && isClientConnected(client)) {
+    client.flush(); 
+  }
 }
 
 /* ------------------------------------------------- */
 
-void ESPTelnet::println() { 
-  client.print("\n"); 
+size_t ESPTelnet::write(uint8_t data) {
+  if (client && isClientConnected(client)) {
+    return client.write(data); 
+  } else {
+    return 0;
+  }
 }
 
 /* ------------------------------------------------- */

--- a/src/ESPTelnet.h
+++ b/src/ESPTelnet.h
@@ -41,7 +41,6 @@ class ESPTelnet : public Stream {
     void onConnectionAttempt(CallbackFunction f);
     void onReconnect(CallbackFunction f);
     void onDisconnect(CallbackFunction f);
-    void onInputReceived(CallbackFunction f);
     
   protected:
     WiFiServer server = WiFiServer(23);
@@ -49,7 +48,6 @@ class ESPTelnet : public Stream {
     boolean isConnected = false;
     String ip;
     String attemptIp;
-    String input = "";
 
     bool isClientConnected(WiFiClient client);
 
@@ -57,7 +55,6 @@ class ESPTelnet : public Stream {
     CallbackFunction on_reconnect  = NULL;
     CallbackFunction on_disconnect = NULL;
     CallbackFunction on_connection_attempt = NULL;
-    CallbackFunction on_input  = NULL;
 };
 
 /* ------------------------------------------------- */

--- a/src/ESPTelnet.h
+++ b/src/ESPTelnet.h
@@ -17,7 +17,7 @@
 
 /* ------------------------------------------------- */
 
-class ESPTelnet {
+class ESPTelnet : public Stream {
   typedef void (*CallbackFunction) (String str);
 
   public:
@@ -27,11 +27,12 @@ class ESPTelnet {
     void loop();
     void stop();
 
-    void print(String str);
-    void print(char c);
-    void println(String str);
-    void println(char c);
-    void println();
+    int available();
+    int read();
+    int peek();
+    void flush();
+
+    size_t write(uint8_t);
 
     String getIP() const;
     String getLastAttemptIP() const;


### PR DESCRIPTION
# Description
TCP is a stream protocol and telnet, operating on top of TCP, represents a bidirectional stream.  As such, it would be nice if ESPTelnet inherited from Stream, allowing it to be used in any context that accepts a Stream object.

The main realization here is that WiFiClient already inherits from Stream thus providing full access to all functionality of Stream and Print.  Since ESPTelnet acts as a proxy relaying print functions to the currently active WiFiClient, it is already set up well to do this.  It is unnecessary to implement the print() and println() functions as ESPTelnet was doing.  It need only extend Stream itself and then implement the pure virtual functions of Stream and Print.  It will then inherit all the print, read, and find functions of both Stream and Print.

The already implemented print() and println() functions of ESPTelnet were removed and the pure virtual functions of Stream and Print were added, following the same model.  That is, these calls are relayed to the active WiFiClient, if there is one, otherwise they are ignored.  The pure virtual functions constitute available(), read(), peek(), and flush() for Stream and write() for Print.

## Type of change
Breaking feature enhancement to have ESPTelnet extend Stream.  
- Commit 06077b9 is a non-breaking change to extend Stream.  The direct implementation of the print functions is removed, but their implementation is now inherited from Print.  Thus, functionality is added and no functionality is lost.
- Commit 6a48200 is a breaking change.  It removes the functionality of the input received callback since that would interfere with the normal use of a Stream object.

# Testing
The changes have been tested in PlatformIO using the Arduino framework on a DevKitC board.  The platformio.ini is as follows:
```
[env:esp32dev]
platform = espressif32
board = esp32dev
framework = arduino
```
The test application simply connects together the input and output of the serial monitor with the connected telnet client.  The code for this is as follows.
```
#if defined(ARDUINO_ARCH_ESP32)
  #include <WiFi.h>
  #include <WebServer.h>
#elif defined(ARDUINO_ARCH_ESP8266)
  #include <ESP8266WiFi.h>
  #include <ESP8266WebServer.h>
#endif

#include <ESPTelnet.h>


#define INFRA_SSID  "Secret"
#define INFRA_PSWD  "AnotherSecret"

ESPTelnet telnet;


void telnetConnected(String ip)
{
  Serial.print(ip);
  Serial.println(" connected.");
}

void telnetDisconnected(String ip)
{
  Serial.print(ip);
  Serial.println(" disconnected.");
}

void telnetReconnect(String ip)
{
  Serial.print(ip);
  Serial.println(" reconnected.");
}


void setup() {
  Serial.begin(115200);
  Serial.println("ESP Telnet Test");

  WiFi.mode(WIFI_STA);
  WiFi.begin(INFRA_SSID, INFRA_PSWD);
  while(WiFi.status() != WL_CONNECTED) {
    delay(100);
  }

  telnet.onConnect(telnetConnected);
  telnet.onDisconnect(telnetDisconnected);
  telnet.onReconnect(telnetReconnect);

  Serial.print("Telnet.begin: ");
  if(telnet.begin()) {
    Serial.println("Successful");
  } else {
    Serial.println("Failed");
  }
}

void loop() {
  telnet.loop();
  if(Serial.available() > 0) {
    telnet.println(Serial.readString());
  }
  if (telnet.available() > 0) {    
    Serial.println(telnet.readString());
  }
}
```
Tera Term was used for both sides of the connection (serial monitor and telnet).
