### PR TITLE
Ethernet support

### DIFF
--- a/src/ESPTelnet.cpp
+++ b/src/ESPTelnet.cpp
@@ -24,8 +24,12 @@ bool ESPTelnet::_isIPSet(IPAddress ip) {
 
 bool ESPTelnet::begin(uint16_t port /* = 23 */) {
   ip = "";
-  // connected to WiFi or is ESP in AP mode?
-  // if (WiFi.status() == WL_CONNECTED || _isIPSet(WiFi.softAPIP())) {
+  // connected to WiFi, Ethernet, or is ESP in AP mode?
+  bool isConnected = WiFi.status() == WL_CONNECTED || _isIPSet(WiFi.softAPIP());
+#ifdef ETH_PHY_TYPE
+  isConnected = isConnected || _isIPSet(ETH.localIP());
+#endif
+  if (isConnected) {
     server_port = port;
     if (port != 23) {
       server = WiFiServer(port);
@@ -33,9 +37,9 @@ bool ESPTelnet::begin(uint16_t port /* = 23 */) {
     server.begin();
     server.setNoDelay(true);
     return true;
-  // } else {
-  //   return false;
-  // }
+  } else {
+    return false;
+  }
 }
 
 /* ------------------------------------------------- */

--- a/src/ESPTelnet.cpp
+++ b/src/ESPTelnet.cpp
@@ -25,7 +25,7 @@ bool ESPTelnet::_isIPSet(IPAddress ip) {
 bool ESPTelnet::begin(uint16_t port /* = 23 */) {
   ip = "";
   // connected to WiFi or is ESP in AP mode?
-  if (WiFi.status() == WL_CONNECTED || _isIPSet(WiFi.softAPIP())) {
+  // if (WiFi.status() == WL_CONNECTED || _isIPSet(WiFi.softAPIP())) {
     server_port = port;
     if (port != 23) {
       server = WiFiServer(port);
@@ -33,9 +33,9 @@ bool ESPTelnet::begin(uint16_t port /* = 23 */) {
     server.begin();
     server.setNoDelay(true);
     return true;
-  } else {
-    return false;
-  }
+  // } else {
+  //   return false;
+  // }
 }
 
 /* ------------------------------------------------- */

--- a/src/ESPTelnet.h
+++ b/src/ESPTelnet.h
@@ -9,6 +9,9 @@
 
 #if defined(ARDUINO_ARCH_ESP32)
   #include <WiFi.h>
+#ifdef ETH_PHY_TYPE
+  #include <ETH.h>
+#endif
 #elif defined(ARDUINO_ARCH_ESP8266)
   #include <ESP8266WiFi.h>
   #include <ESP8266WebServer.h>


### PR DESCRIPTION
Hi, thank you for the library!

I'm using it (just started) on WT32-ETH01, which supports an Ethernet connection instead of WiFi. To make it work, I had to add a tiny change to the "begin" method.

`ETH_PHY_TYPE` - describes what physical chip is used for Ethernet communication, so we can use it to add an additional check and include.

Tested on WT32-ETH01 and regular ESP32 chip with WiFi.