### PR TITLE
feat(ethernet): Added Ethernet support

### DIFF
--- a/src/ESPTelnetBase.cpp
+++ b/src/ESPTelnetBase.cpp
@@ -37,12 +37,13 @@ void ESPTelnetBase::loop() {
 /////////////////////////////////////////////////////////////////
 
 void ESPTelnetBase::processClientConnection() {
+  // Ethernet Server uses a different client check protocol, it's checked AFTER the accept() call
 
-  if (!server.hasClient()) return;        // This code operates on WiFiClients
+  if(!server.useEthernet() && !server.hasClient()) return;  // This code operates on WiFiClients
 
   TCPClient newClient = server.accept();
 
-  if (!newClient) return;                 // This code operates on EthernetClients
+  if(server.useEthernet() && !newClient) return;            // This code operates on EthernetClients
 
   if (!connected) {
     connectClient(newClient);

--- a/src/ESPTelnetBase.h
+++ b/src/ESPTelnetBase.h
@@ -21,6 +21,7 @@
 #include <ESP8266WebServer.h>
 #include <ESP8266WiFi.h>
 #endif
+#include <Ethernet.h>
 
 /////////////////////////////////////////////////////////////////
 
@@ -28,17 +29,104 @@
 
 /////////////////////////////////////////////////////////////////
 
-using TCPClient = WiFiClient;
-using TCPServer = WiFiServer;
+class TCPClient : public WiFiClient, EthernetClient {
+  public:
+    TCPClient() : _useEthernet(false) {}
+
+// Convenience methods
+    bool useEthernet(void) { return _useEthernet; }
+    const char *connection(void) { return _useEthernet ? "Ethernet" : "WiFi"; }
+
+// Methods override
+    int read() { return _useEthernet ? EthernetClient::read() : WiFiClient::read(); }
+    int read(uint8_t *buf, size_t size) { return _useEthernet ? EthernetClient::read(buf, size) : WiFiClient::read(buf, size); }
+    size_t write(uint8_t data) { return _useEthernet ? EthernetClient::write(data) : WiFiClient::write(data); }
+    size_t write(const uint8_t *buf, size_t size) { return _useEthernet ? EthernetClient::write(buf, size) : WiFiClient::write(buf, size); }
+    int available() { return _useEthernet ? EthernetClient::available() : WiFiClient::available(); }
+    int peek() { return _useEthernet ? EthernetClient::peek() : WiFiClient::peek(); }
+    uint8_t connected() { return _useEthernet ? EthernetClient::connected() : WiFiClient::connected(); }
+    IPAddress remoteIP() override { return _useEthernet ? EthernetClient::remoteIP() : WiFiClient::remoteIP(); }
+    IPAddress remoteIP(int fd) { return _useEthernet ? EthernetClient::remoteIP() : WiFiClient::remoteIP(fd); }
+    void flush() { if(_useEthernet) EthernetClient::flush(); else WiFiClient::flush(); }
+    void stop() { if(_useEthernet) EthernetClient::stop(); else WiFiClient::stop(); }
+    void setNoDelay(bool nodelay) { if(!_useEthernet) WiFiClient::setNoDelay(nodelay); }
+
+// Copy constructors and assignment operators
+    TCPClient(EthernetClient ec) : EthernetClient(ec), _useEthernet(true) {}
+    TCPClient(WiFiClient wc) : WiFiClient(wc), _useEthernet(false) {}
+    TCPClient & operator=(const EthernetClient &other) { _useEthernet = true; return *this; }
+    TCPClient & operator=(const WiFiClient &other) { _useEthernet = false; return *this; }
+
+// Conversion operators
+    operator bool() { return _useEthernet ? EthernetClient::operator bool() : WiFiClient::operator bool(); }
+
+// Print methods to keep ESPTelnetStream class happy
+    size_t print(const __FlashStringHelper *ifsh) { return _useEthernet ? EthernetClient::print(ifsh) : WiFiClient::print(ifsh); }
+    size_t print(const String &s)                 { return _useEthernet ? EthernetClient::print(s)  :  WiFiClient::print(s); }
+    size_t print(const char s[])                  { return _useEthernet ? EthernetClient::print(s)  :  WiFiClient::print(s); }
+    size_t print(char c)                          { return _useEthernet ? EthernetClient::print(c)  :  WiFiClient::print(c); }
+    size_t print(unsigned char c, int b = DEC)    { return _useEthernet ? EthernetClient::print(c, b)  :  WiFiClient::print(c, b); }
+    size_t print(int c, int b = DEC)              { return _useEthernet ? EthernetClient::print(c, b)  :  WiFiClient::print(c, b); }
+    size_t print(unsigned int c, int b = DEC)     { return _useEthernet ? EthernetClient::print(c, b)  :  WiFiClient::print(c, b); }
+    size_t print(long l, int b= DEC)              { return _useEthernet ? EthernetClient::print(l, b)  :  WiFiClient::print(l, b); }
+    size_t print(unsigned long l, int b = DEC)    { return _useEthernet ? EthernetClient::print(l, b)  :  WiFiClient::print(l, b); }
+    size_t print(long long l, int b = DEC)        { return _useEthernet ? EthernetClient::print(l, b)  :  WiFiClient::print(l, b); }
+    size_t print(unsigned long long l, int b = DEC) { return _useEthernet ? EthernetClient::print(l, b)  :  WiFiClient::print(l, b); }
+    size_t print(double d, int i = 2)             { return _useEthernet ? EthernetClient::print(d, i)  :  WiFiClient::print(d, i); }
+    size_t print(const Printable& p)              { return _useEthernet ? EthernetClient::print(p)  :  WiFiClient::print(p); }
+    size_t print(struct tm * timeinfo, const char * format = NULL) { return _useEthernet ? EthernetClient::print(timeinfo, format)  :  WiFiClient::print(timeinfo, format); }
+
+    size_t println(const __FlashStringHelper *ifsh)  { return _useEthernet ? EthernetClient::println(ifsh)  :  WiFiClient::println(ifsh); }
+    size_t println(const String &s)               { return _useEthernet ? EthernetClient::println(s)  :  WiFiClient::println(s); }
+    size_t println(const char s[])                { return _useEthernet ? EthernetClient::println(s)  :  WiFiClient::println(s); }
+    size_t println(char c)                        { return _useEthernet ? EthernetClient::println(c)  :  WiFiClient::println(c); }
+    size_t println(unsigned char c, int b = DEC)  { return _useEthernet ? EthernetClient::println(c, b)  :  WiFiClient::println(c, b); }
+    size_t println(int c, int b = DEC)            { return _useEthernet ? EthernetClient::println(c, b)  :  WiFiClient::println(c, b); }
+    size_t println(unsigned int c, int b = DEC)   { return _useEthernet ? EthernetClient::println(c, b)  :  WiFiClient::println(c, b); }
+    size_t println(long l, int b = DEC)           { return _useEthernet ? EthernetClient::println(l, b)  :  WiFiClient::println(l, b); }
+    size_t println(unsigned long l, int b = DEC)  { return _useEthernet ? EthernetClient::println(l, b)  :  WiFiClient::println(l, b); }
+    size_t println(long long l, int b = DEC)      { return _useEthernet ? EthernetClient::println(l, b)  :  WiFiClient::println(l, b); }
+    size_t println(unsigned long long l, int b = DEC) { return _useEthernet ? EthernetClient::println(l, b)  :  WiFiClient::println(l, b); }
+    size_t println(double d, int b = 2)           { return _useEthernet ? EthernetClient::println(d, b)  :  WiFiClient::println(d, b); }
+    size_t println(const Printable&p)             { return _useEthernet ? EthernetClient::println(p)  :  WiFiClient::println(p); }
+    size_t println(struct tm * timeinfo, const char * format = NULL) { return _useEthernet ? EthernetClient::println(timeinfo, format)  :  WiFiClient::println(timeinfo, format); }
+    size_t println(void)                         { return _useEthernet ? EthernetClient::println()  :  WiFiClient::println(); }
+
+  protected:
+    bool _useEthernet;
+};
 
 /////////////////////////////////////////////////////////////////
+
+class TCPServer : public WiFiServer, EthernetServer {
+  public:
+    TCPServer(uint16_t port, bool useEthernet = false) : WiFiServer(port), EthernetServer(port), _useEthernet(useEthernet) {}
+
+// Methods override
+    TCPClient accept() {if(_useEthernet) return EthernetServer::accept(); else return WiFiServer::accept(); }
+    bool hasClient() { return _useEthernet ? true : WiFiServer::hasClient(); }
+
+    void begin(uint16_t port=0) {if(_useEthernet) EthernetServer::begin(); else WiFiServer::begin(port); }
+    void begin(uint16_t port, int reuse_enable) {if(_useEthernet) EthernetServer::begin(); else WiFiServer::begin(port, reuse_enable); }
+
+// Convenience methods
+    bool useEthernet(void) { return _useEthernet; }
+    const char *connection(void) { return _useEthernet ? "Ethernet" : "WiFi";}
+
+  protected:
+    bool _useEthernet;
+};
+
+
+/////////////////////////////////////////////////////////////////
+
 class ESPTelnetBase {
   typedef void (*CallbackFunction)(String str);
 
  public:
   ESPTelnetBase();
 
-  bool begin(uint16_t port = 23, bool checkConnection = true);
+  bool begin(uint16_t port = 23, bool checkWiFiConnection = true, bool useEthernet = false);
   void stop();
   void loop();
 
@@ -58,7 +146,7 @@ class ESPTelnetBase {
   void onInputReceived(CallbackFunction f);
 
  protected:
-  TCPServer server = TCPServer(23);  // must be initalized here
+  TCPServer server; // = TCPServer(23);  // must be initalized here  ==> WHY ?
   TCPClient client;
   bool connected = false;  // needed because I cannot do "client = NULL"
   String ip = "";
@@ -91,6 +179,7 @@ class ESPTelnetBase {
   bool doKeepAliveCheckNow();
 
 };
+
 
 /////////////////////////////////////////////////////////////////
 #endif


### PR DESCRIPTION
# Abstracted TCPClient and TCPServer classes to make as transparent as possible to switch between network interfaces

Hi Lennart!

I managed to create a transparency class to abstract as much as possible the differences between WiFi and Ethernet interfaces in your Telnet library.

I feel a little rusted on C++ inheritance and probably this same code could be enhanced and made clearer, but at least it:
 - Does not break existing WiFi code
 - It modifies very liitle ESPTelnet code and concentrates on Client and Server classes, so I don't think it could impact performance on WiFi users (the only ones that may exist by now)
 - It works!

Please fell free to add or modify anything you like  (It's YOUR library after all  :-) ) and merge it or not to the main branch. I will use the fork in my repo for my project because I'm in a hurry and it fits my needs. When, in the future, you feel satisfied with the tests you consider and finally merge it, future versions of my project will link it.

Cheers!!
