### PR TITLE
Expose vprintf to external code to allow using ESP-IDF's standard logger library

### DIFF
--- a/examples/TelnetESPLoggerExample/TelnetESPLoggerExample.ino
+++ b/examples/TelnetESPLoggerExample/TelnetESPLoggerExample.ino
@@ -1,0 +1,148 @@
+// An example showing how to use ESPTelnet with the standard ESP logger
+
+/* ------------------------------------------------- */
+
+#include <Arduino.h>
+#include <esp32-hal-log.h>
+#include "ESPTelnet.h"
+
+/* ------------------------------------------------- */
+
+#define SERIAL_SPEED    9600
+#define WIFI_SSID       "MY SSID"
+#define WIFI_PASSWORD   "MY PASS"
+
+/* ------------------------------------------------- */
+
+ESPTelnet telnet;
+IPAddress ip;
+uint16_t  port = 23;
+static const char LOG_TAG[] = "TelnetLog";
+static TaskHandle_t hTelnet = NULL;
+
+/* ------------------------------------------------- */
+
+static void telnet_task(void*) {
+    while(1) {
+        telnet.loop();
+        delay(100);
+    }
+    vTaskDelete(NULL);
+}
+
+// This function will be called by the ESP log library every time ESP_LOG needs to be performed when the telnet server is started.
+// Do NOT use the ESP_LOG* macro's in this function or things will explodify!
+int _telnet_log_vprintf(const char *fmt, va_list args) {
+    telnet.vprintf(fmt, args);
+    return vprintf(fmt, args);
+}
+
+/* ------------------------------------------------- */
+
+void setupSerial(long speed, String msg = "") {
+  Serial.begin(speed);
+  while (!Serial) {
+  }
+  delay(200);  
+  Serial.println();
+  Serial.println();
+  if (msg != "") Serial.println(msg);
+}
+
+/* ------------------------------------------------- */
+
+bool isConnected() {
+  return (WiFi.status() == WL_CONNECTED);
+}
+
+/* ------------------------------------------------- */
+
+bool connectToWiFi(const char* ssid, const char* password, int max_tries = 20, int pause = 500) {
+  int i = 0;
+  WiFi.mode(WIFI_STA);
+  WiFi.disconnect();
+  delay(100);
+  
+  #if defined(ARDUINO_ARCH_ESP8266)
+    WiFi.forceSleepWake();
+    delay(200);
+  #endif
+  WiFi.begin(ssid, password);
+  do {
+    delay(pause);
+    Serial.print(".");
+    i++;
+  } while (!isConnected() && i < max_tries);
+  WiFi.setAutoReconnect(true);
+  WiFi.persistent(true);
+  return isConnected();
+}
+
+/* ------------------------------------------------- */
+
+void errorMsg(String error, bool restart = true) {
+  Serial.println(error);
+  if (restart) {
+    Serial.println("Rebooting now...");
+    delay(2000);
+    ESP.restart();
+    delay(2000);
+  }
+}
+
+/* ------------------------------------------------- */
+
+void setupTelnet() {  
+  Serial.print("- Telnet: ");
+  if (telnet.begin(port)) {
+    Serial.println("running");
+  } else {
+    Serial.println("error.");
+    errorMsg("Will reboot...");
+  }
+}
+
+void setupLogging() {
+  xTaskCreate(
+      telnet_task,
+      "TELOG",
+      4096,
+      NULL,
+      1,
+      &hTelnet
+  );
+  esp_log_set_vprintf(_telnet_log_vprintf);
+}
+
+/* ------------------------------------------------- */
+
+void setup() {
+  setupSerial(SERIAL_SPEED, "Telnet Test");
+  
+  Serial.print("- Wifi: ");
+  connectToWiFi(WIFI_SSID, WIFI_PASSWORD);
+  
+  if (isConnected()) {
+    ip = WiFi.localIP();
+    Serial.println();
+    Serial.print("- Telnet: "); Serial.print(ip); Serial.print(":"); Serial.println(port);
+    setupTelnet();
+    setupLogging();
+  } else {
+    Serial.println();    
+    errorMsg("Error connecting to WiFi");
+  }
+}
+
+/* ------------------------------------------------- */
+
+void loop() {
+  ESP_LOGI(LOG_TAG, "Info!");
+  delay(1000);
+  ESP_LOGW(LOG_TAG, "Warning!");
+  delay(1000);
+  ESP_LOGE(LOG_TAG, "Error!");
+  delay(1000);
+}
+
+//* ------------------------------------------------- */

--- a/src/ESPTelnet.cpp
+++ b/src/ESPTelnet.cpp
@@ -47,10 +47,13 @@ size_t ESPTelnet::printf(const char* format, ...) {
   
   va_list arg;
   va_start(arg, format);
+  vprintf(format, arg);
+  va_end(arg);
+}
+
+size_t ESPTelnet::vprintf(const char* format, va_list arg) {
   char loc_buf[64];
   int len = vsnprintf(loc_buf, sizeof(loc_buf), format, arg);
-  va_end(arg);
-
   if (len < 0) return 0;
 
   if (len >= (int)sizeof(loc_buf)) {
@@ -58,9 +61,7 @@ size_t ESPTelnet::printf(const char* format, ...) {
     if (temp == nullptr) {
       return 0;
     }
-    va_start(arg, format);
     vsnprintf(temp, len + 1, format, arg);
-    va_end(arg);
     len = write((uint8_t*)temp, len);
     free(temp);
   } else {

--- a/src/ESPTelnet.cpp
+++ b/src/ESPTelnet.cpp
@@ -2,6 +2,10 @@
 
 #include "ESPTelnet.h"
 
+#ifndef ESPTELNET_VPRINTF_BUFFER_SIZE
+#define ESPTELNET_VPRINTF_BUFFER_SIZE 64
+#endif
+
 /////////////////////////////////////////////////////////////////
 
 void ESPTelnet::handleInput() {
@@ -47,12 +51,13 @@ size_t ESPTelnet::printf(const char* format, ...) {
   
   va_list arg;
   va_start(arg, format);
-  vprintf(format, arg);
+  size_t len = vprintf(format, arg);
   va_end(arg);
+  return len;
 }
 
 size_t ESPTelnet::vprintf(const char* format, va_list arg) {
-  char loc_buf[64];
+  char loc_buf[ESPTELNET_VPRINTF_BUFFER_SIZE];
   int len = vsnprintf(loc_buf, sizeof(loc_buf), format, arg);
   if (len < 0) return 0;
 

--- a/src/ESPTelnet.h
+++ b/src/ESPTelnet.h
@@ -61,6 +61,7 @@ class ESPTelnet : public ESPTelnetBase {
 
   void println();
   size_t printf(const char *format, ...);
+  size_t vprintf(const char *format, va_list);
 
   bool isLineModeSet();
   void setLineMode(bool value = true);


### PR DESCRIPTION
This is a great library for the times when you want to add a telnet log but CBA to do the sockets and stuff from scratch or ask whatever LLM to do it for you. 

However, adding it to an existing project that already uses ESP_LOG statements and migrating to this library's macros could be painful, e.g. for a project on the scale of https://github.com/vladkorotnev/cd-player

While one could just vsnprintf in their own code and then call this library's print function, that has memory implications and running the formatting code basically twice. 

Exposing the vprintf method allows for more flexibility, and specifically easier implementation of this specific thing!

Here is how it works with the standard ESP library:
<img width="720" alt="image" src="https://github.com/user-attachments/assets/0791509d-1a3e-42b1-9e20-7116dbcbd0fc" />


P.S. I do not have an Arduino IDE setup so the example was made on a whim, holler if it breaks.